### PR TITLE
Fix minor bug in URL redaction with missed trailing forward slash

### DIFF
--- a/lib/patterns.js
+++ b/lib/patterns.js
@@ -21,5 +21,5 @@ module.exports = {
   salutation: /(^|\n(\s+)?)(dear|hi|hey|hello|greetings) ([^,:;\s]+(,? )?){1,5}[,;\n]/gi,
   valediction: /([Tt]hank(s| you)( for [^!,.]+| again)?|[Cc]heers|[Ss]incerely|[Rr]egards|[Rr]espectfully|[Bb]est|[Bb]est regards|[Yy]ours truly)\s*[!,.]?\s*([A-Z&]([\w&]+)?\.?( )?)+[^a-z]*$/g,
   digits: /\d+/g,
-  url: /([^\s:/?#]+):\/\/([^/?#\s]*)([^?#\s]*)(\?([^#\s]*))?(#([^\s]*))?\b/
+  url: /([^\s:/?#]+):\/\/([^/?#\s]*)([^?#\s]*)(\?([^#\s]*))?(#([^\s]*))?/
 };

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -169,7 +169,7 @@ defineTest('index.js', function (Redactor) {
 
   it('should replace URLs', function () {
     redactor.redact('My homepage is http://example.com').should.equal('My homepage is URL');
-    redactor.redact('ip http://127.0.01/example.html test').should.equal('ip URL test');
+    redactor.redact('ip http://127.0.0.1/example.html test').should.equal('ip URL test');
     redactor.redact('custom protocol myapp://example.com').should.equal('custom protocol URL');
     redactor.redact('Reset password url is https://example.com/reset/password/12345').should.equal('Reset password url is URL');
     redactor.redact('complex http://user@pass:example.com:8080/reset/password/12345?foo=bar&hi=there#/app works?').should.equal('complex URL works?');
@@ -179,6 +179,8 @@ defineTest('index.js', function (Redactor) {
     redactor.redact('before http://www.example.com/foo/bar after').should.equal('before URL after');
     redactor.redact('before http://www.example.com/foo/bar?foo=bar after').should.equal('before URL after');
     redactor.redact('before http://www.example.com/foo/bar?foo=bar#/foo/bar after').should.equal('before URL after');
+    redactor.redact('before http://www.example.com/sub/dir/ after').should.equal('before URL after');
+    redactor.redact('My homepage is http://example.com\nAnd that is that.').should.equal('My homepage is URL\nAnd that is that.');
   });
 
 });


### PR DESCRIPTION
This fixes a minor bug where a trailing forward slash would get missed by the URL redaction (e.g. "http://example.com/foo/" was becoming "URL/")
