### PR TITLE
Automatically split too large DLP input into smaller batches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Changelog
 
+## [3.2.0][] - 2019-05-21
+- Add enhancement to automatically split Google DLP input that is too large into smaller batches. This can be disabled with the `disableAutoBatchWhenContentSizeExceedsLimit` option. 
+ 
 ## [3.1.0][] - 2019-05-04
 - BREAKING: rename `replacementValue` param of built-in redaction config to `replaceWith` for consistency
  
@@ -27,7 +30,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Google Cloud DLP redaction does not have an implicit, hard-coded 5000ms timeout anymore. If you want to set a timeout for DLP calls you have to implement it yourself. In case you're using `bluebird` as promise library consider using `.timeout`.
  
 
-[Unreleased]: https://github.com/solvvy/redact-pii/compare/v3.1.0...HEAD
+[Unreleased]: https://github.com/solvvy/redact-pii/compare/v3.2.0...HEAD
+[3.2.0]: https://github.com/solvvy/redact-pii/compare/v3.1.0...v3.2.0
 [3.1.0]: https://github.com/solvvy/redact-pii/compare/v3.0.1...v3.1.0
 [3.0.1]: https://github.com/solvvy/redact-pii/compare/v3.0.0...v3.0.1
 [3.0.0]: https://github.com/solvvy/redact-pii/tree/v3.0.0

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ redactor.redactAsync('I live at 123 Park Ave Apt 123 New York City, NY 10002 and
 
 #### Google DLP content size limit
 
-The Google DLP service has a content size limit of 524288. If the input is over this limit, the `GoogleDLPRedactor` will 
+The Google DLP service has a content size limit of 524288 bytes. If the input is over this limit, the `GoogleDLPRedactor` will 
 by default automatically split the content into smaller batches and then combine the results together again. If this 
 behavior is undesired, it can be disabled by setting the `disableAutoBatchWhenContentSizeExceedsLimit` option flag to 
 true:

--- a/README.md
+++ b/README.md
@@ -216,6 +216,22 @@ redactor.redactAsync('I live at 123 Park Ave Apt 123 New York City, NY 10002 and
 });
 ```
 
+#### Google DLP content size limit
+
+The Google DLP service has a content size limit of 524288. If the input is over this limit, the `GoogleDLPRedactor` will 
+by default automatically split the content into smaller batches and then combine the results together again. If this 
+behavior is undesired, it can be disabled by setting the `disableAutoBatchWhenContentSizeExceedsLimit` option flag to 
+true:
+
+```js
+new GoogleDLPRedactor({ disableAutoBatchWhenContentSizeExceedsLimit: true })
+
+```
+
+There is no intelligence to try to prevent splitting the batches in the middle of a word.  If the batch happens to be 
+split in the middle of a sensitive word then that word may not be redacted. You can always perform your own intelligent
+batching prior if needed.
+
 ### Contributing
 
 #### Run tests

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "redact-pii",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redact-pii",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "Remove personally identifiable information from text.",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/custom/GoogleDLPRedactor.ts
+++ b/src/custom/GoogleDLPRedactor.ts
@@ -133,7 +133,9 @@ export class GoogleDLPRedactor implements IAsyncRedactor {
     this.dlpClient = new DLP.DlpServiceClient(this.opts.clientOptions);
   }
   async redactAsync(textToRedact: string): Promise<string> {
-    const maxContentSize = this.opts.maxContentSizeForBatch || MAX_DLP_CONTENT_LENGTH;
+    // default batch size is MAX_DLP_CONTENT_LENGTH/2 because some unicode characters can take more than 1 byte
+    // and its difficult to get a substring of a desired target length in bytes
+    const maxContentSize = this.opts.maxContentSizeForBatch || MAX_DLP_CONTENT_LENGTH/2;
 
     if (textToRedact.length > maxContentSize && !this.opts.disableAutoBatchWhenContentSizeExceedsLimit) {
       const batchResults = [];


### PR DESCRIPTION
The Google DLP service has a content size limit of 524288 and will return an error like `INVALID_ARGUMENT: Content size 637480 exceeds limit of 524288` when the input is too large.

This enhancement enables automatically splitting into smaller batches for large input. This behavior can be disabled with `disableAutoBatchWhenContentSizeExceedsLimit`.