### PR TITLE
Support overriding `replaceWith` for built in redactors

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ const redactor = new AsyncRedactor({
 });
 ```
 
-### Disable specific built-in redaction rules
+### Disable or override specific built-in redaction rules
 
 ```js
 const redactor = new SyncRedactor({
@@ -151,7 +151,7 @@ const redactor = new SyncRedactor({
       enabled: false
     },
     emailAddress: {
-      enabled: false
+      replaceWith: "redacted@example.com"
     }
   }
 });

--- a/src/composition.ts
+++ b/src/composition.ts
@@ -38,14 +38,17 @@ export function composeChildRedactors<T extends AsyncCustomRedactorConfig>(opts:
       childRedactors.push(
         new SimpleRegexpRedactor({
           regexpPattern: (simpleRegexpBuiltIns as any)[regexpName],
-          replaceWith: opts.globalReplaceWith || snakeCase(regexpName).toUpperCase(),
+          replaceWith:
+            (opts.builtInRedactors as any)?.[regexpName]?.replaceWith ||
+            opts.globalReplaceWith ||
+            snakeCase(regexpName).toUpperCase(),
         })
       );
     }
   }
 
   if (!opts.builtInRedactors || !opts.builtInRedactors.names || opts.builtInRedactors.names.enabled !== false) {
-    childRedactors.push(new NameRedactor(opts.globalReplaceWith));
+    childRedactors.push(new NameRedactor(opts.builtInRedactors?.names?.replaceWith || opts.globalReplaceWith));
   }
 
   if (opts.customRedactors && opts.customRedactors.after) {

--- a/test/redactor.test.ts
+++ b/test/redactor.test.ts
@@ -191,6 +191,17 @@ describe('index.js', function () {
     expect(redactor.redact('I love cats, dogs, and cows')).toBe('I love ANIMAL, ANIMAL, and ANIMAL');
   });
 
+  it('should accept custom replacements for built in redactors', function () {
+    let redactor = new SyncRedactor({
+      builtInRedactors: {
+        emailAddress: { replaceWith: '<REDACTED_EMAIL>' },
+        names: { replaceWith: '<REDACTED_NAME>' },
+      },
+    });
+    expect(redactor.redact('My email: joe123@solvvy.co.uk.')).toBe('My email: <REDACTED_EMAIL>.');
+    expect(redactor.redact('My name is Joshua')).toBe('My name is <REDACTED_NAME>');
+  });
+
   TestCase('should replace digits', [['codeA: 123, codeB: 6789', 'codeA: 123, codeB: DIGITS']]);
 
   TestCase('should replace URLs', [


### PR DESCRIPTION
Sometimes you might want to use the built in redactors, but override the `replaceWith` values. This lets you do that.

```js
const redactor = new SyncRedactor({
  builtInRedactors: {
    emailAddress: { replaceWith: '<REDACTED_EMAIL>' },
    names: { replaceWith: '<REDACTED_NAME>' },
  },
});
 ```

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fixes #34
> Fixes #70
> Closes #46

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
